### PR TITLE
Completely disable the revalidation

### DIFF
--- a/stubs/php.ini
+++ b/stubs/php.ini
@@ -26,8 +26,8 @@ opcache.interned_strings_buffer=16
 ; The maximum number of keys (and therefore scripts) in the OPcache hash table.
 opcache.max_accelerated_files=10000
 
-; How often to check script timestamps for updates, in seconds.
-opcache.revalidate_freq=60
+; Disable the revalidation completely.
+opcache.validate_timestamps=0
 
 ; Use tracing JIT.
 opcache.jit=tracing


### PR DESCRIPTION
Because the application runs on the ephemeral container and the code only changes when it's deployed again, we don't need to check for file updates and refresh the cache every minute if necessary, so removing the revalidation mechanism gives us a little extra performance boost.