### PR TITLE
Configure static FPM processes

### DIFF
--- a/stubs/php-fpm.conf
+++ b/stubs/php-fpm.conf
@@ -15,11 +15,10 @@ user = nobody
 ; The socket to accept FastCGI requests
 listen = /tmp/.dew/php-fpm.sock
 
-; Dynamically control the number of workers
-pm = dynamic
-pm.max_children = 5
-pm.min_spare_servers = 1
-pm.max_spare_servers = 3
+; Container processes only one request at a time
+pm = static
+pm.max_children = 1
+pm.max_requests = 250
 
 ; Redirect workers output to STDERR
 catch_workers_output = true


### PR DESCRIPTION
Because the container will only accept one concurrency request, we do not need to dynamically allocate more than one worker.

On the other hand, we specify the maximum number of requests a worker can handle to prevent unexpected memory leaks.