### PR TITLE
Update php versions

### DIFF
--- a/php81-debian10/Dockerfile
+++ b/php81-debian10/Dockerfile
@@ -241,7 +241,7 @@ RUN make -j$(nproc) && make install
 #   - pgsql
 #   - zlib
 
-ENV PHP_VERSION=8.1.24
+ENV PHP_VERSION=8.1.27
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
 ENV PHP_INI_DIR=${INSTALL_DIR}/etc/php
 

--- a/php81/Dockerfile
+++ b/php81/Dockerfile
@@ -263,7 +263,7 @@ RUN make -j$(nproc) && make install
 #   - pgsql
 #   - zlib
 
-ENV PHP_VERSION=8.1.24
+ENV PHP_VERSION=8.1.27
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
 ENV PHP_INI_DIR=${INSTALL_DIR}/etc/php
 

--- a/php82-debian10/Dockerfile
+++ b/php82-debian10/Dockerfile
@@ -241,7 +241,7 @@ RUN make -j$(nproc) && make install
 #   - pgsql
 #   - zlib
 
-ENV PHP_VERSION=8.2.11
+ENV PHP_VERSION=8.2.15
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
 ENV PHP_INI_DIR=${INSTALL_DIR}/etc/php
 

--- a/php82/Dockerfile
+++ b/php82/Dockerfile
@@ -263,7 +263,7 @@ RUN make -j$(nproc) && make install
 #   - pgsql
 #   - zlib
 
-ENV PHP_VERSION=8.2.11
+ENV PHP_VERSION=8.2.15
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
 ENV PHP_INI_DIR=${INSTALL_DIR}/etc/php
 


### PR DESCRIPTION
The PR updates two PHP minor releases for PHP 8.1 and PHP 8.2 to:

- PHP 8.1.27
- PHP 8.2.15