### PR TITLE
Upgrade PHP versions

### DIFF
--- a/custom-builder/Dockerfile
+++ b/custom-builder/Dockerfile
@@ -81,7 +81,7 @@ ENV LIBSQLITE3_BUILD_DIR=${BUILD_DIR}/libsqlite3
 WORKDIR ${LIBSQLITE3_BUILD_DIR}/
 
 RUN set -xe; \
-    curl -sL https://sqlite.org/src/tarball/version-${LIBSQLITE3_VERSION}/sqlite.tar.gz \
+    curl -sL https://github.com/sqlite/sqlite/archive/refs/tags/version-${LIBSQLITE3_VERSION}.tar.gz \
     | tar xzC ${LIBSQLITE3_BUILD_DIR} --strip-components 1
 
 RUN CFLAGS="-O2 -pipe" \

--- a/custom-debian10-builder/Dockerfile
+++ b/custom-debian10-builder/Dockerfile
@@ -74,7 +74,7 @@ ENV LIBSQLITE3_BUILD_DIR=${BUILD_DIR}/libsqlite3
 WORKDIR ${LIBSQLITE3_BUILD_DIR}/
 
 RUN set -xe; \
-    curl -sL https://sqlite.org/src/tarball/version-${LIBSQLITE3_VERSION}/sqlite.tar.gz \
+    curl -sL https://github.com/sqlite/sqlite/archive/refs/tags/version-${LIBSQLITE3_VERSION}.tar.gz \
     | tar xzC ${LIBSQLITE3_BUILD_DIR} --strip-components 1
 
 RUN CFLAGS="-O2 -pipe" \

--- a/custom-debian11-builder/Dockerfile
+++ b/custom-debian11-builder/Dockerfile
@@ -75,7 +75,7 @@ ENV LIBSQLITE3_BUILD_DIR=${BUILD_DIR}/libsqlite3
 WORKDIR ${LIBSQLITE3_BUILD_DIR}/
 
 RUN set -xe; \
-    curl -sL https://sqlite.org/src/tarball/version-${LIBSQLITE3_VERSION}/sqlite.tar.gz \
+    curl -sL https://github.com/sqlite/sqlite/archive/refs/tags/version-${LIBSQLITE3_VERSION}.tar.gz \
     | tar xzC ${LIBSQLITE3_BUILD_DIR} --strip-components 1
 
 RUN CFLAGS="-O2 -pipe" \

--- a/php81-debian11/dependencies.ini
+++ b/php81-debian11/dependencies.ini
@@ -1,16 +1,16 @@
 [versions]
 roadrunner = 2024.2.1
-icu4c = 73.2
-libsqlite3 = 3.47.1
-libpq = 17.2
-openssl = 3.4.0
+icu4c = 77.1
+libsqlite3 = 3.50.4
+libpq = 17.6
+openssl = 3.5.2
 zlib = 1.3.1
 libssh2 = 1.11.1
-nghttp2 = 1.64.0
+nghttp2 = 1.66.0
 libpsl = 0.21.5
-curl = 8.11.0
-onig = 6.9.9
-libxml2 = 2.13.5
+curl = 8.15.0
+onig = 6.9.10
+libxml2 = 2.14.5
 libargon2 = 20190702
-libzip = 1.11.2
-php = 8.1.31
+libzip = 1.11.4
+php = 8.1.33

--- a/php82-debian11/dependencies.ini
+++ b/php82-debian11/dependencies.ini
@@ -1,16 +1,16 @@
 [versions]
 roadrunner = 2024.2.1
-icu4c = 73.2
-libsqlite3 = 3.47.1
-libpq = 17.2
-openssl = 3.4.0
+icu4c = 77.1
+libsqlite3 = 3.50.4
+libpq = 17.6
+openssl = 3.5.2
 zlib = 1.3.1
 libssh2 = 1.11.1
-nghttp2 = 1.64.0
+nghttp2 = 1.66.0
 libpsl = 0.21.5
-curl = 8.11.0
-onig = 6.9.9
-libxml2 = 2.13.5
+curl = 8.15.0
+onig = 6.9.10
+libxml2 = 2.14.5
 libargon2 = 20190702
-libzip = 1.11.2
-php = 8.2.26
+libzip = 1.11.4
+php = 8.2.29

--- a/php83-debian11/dependencies.ini
+++ b/php83-debian11/dependencies.ini
@@ -1,16 +1,16 @@
 [versions]
 roadrunner = 2024.2.1
-icu4c = 73.2
-libsqlite3 = 3.47.1
-libpq = 17.2
-openssl = 3.4.0
+icu4c = 77.1
+libsqlite3 = 3.50.4
+libpq = 17.6
+openssl = 3.5.2
 zlib = 1.3.1
 libssh2 = 1.11.1
-nghttp2 = 1.64.0
+nghttp2 = 1.66.0
 libpsl = 0.21.5
-curl = 8.11.0
-onig = 6.9.9
-libxml2 = 2.13.5
+curl = 8.15.0
+onig = 6.9.10
+libxml2 = 2.14.5
 libargon2 = 20190702
-libzip = 1.11.2
-php = 8.3.14
+libzip = 1.11.4
+php = 8.3.24

--- a/php84-debian11/dependencies.ini
+++ b/php84-debian11/dependencies.ini
@@ -1,16 +1,16 @@
 [versions]
 roadrunner = 2024.2.1
-icu4c = 73.2
-libsqlite3 = 3.47.1
-libpq = 17.2
-openssl = 3.4.0
+icu4c = 77.1
+libsqlite3 = 3.50.4
+libpq = 17.6
+openssl = 3.5.2
 zlib = 1.3.1
 libssh2 = 1.11.1
-nghttp2 = 1.64.0
+nghttp2 = 1.66.0
 libpsl = 0.21.5
-curl = 8.11.0
-onig = 6.9.9
-libxml2 = 2.13.5
+curl = 8.15.0
+onig = 6.9.10
+libxml2 = 2.14.5
 libargon2 = 20190702
-libzip = 1.11.2
-php = 8.4.1
+libzip = 1.11.4
+php = 8.4.11


### PR DESCRIPTION
The PR focuses on updating dependencies for the custom runtime based on Debian 11 and the actively supported PHP versions.

## Updated PHP Versions

- 8.4.11
- 8.3.24
- 8.2.29
- 8.1.33

## Updated Dependencies

- icu4c 77.1
- libsqlite3 3.50.4
- libpq 17.6
- openssl 3.5.2
- nghttp2 1.66.0
- curl 8.15.0
- onig 6.9.10
- libxml2 2.14.5
- libzip 1.11.4