### PR TITLE
Stop retaining runtime packages to reduce storage costs

### DIFF
--- a/publish/publish.php
+++ b/publish/publish.php
@@ -140,6 +140,18 @@ function fileUpload(OssClient $client, string $bucket, string $object, string $f
     ]);
 }
 
+function fileDelete(OssClient $client, string $bucket, string $object): void
+{
+    try {
+        $client->deleteObject([
+            'bucket' => $bucket,
+            'key' => $object,
+        ]);
+    } catch (Throwable) {
+        // Ignore any error
+    }
+}
+
 function fileChecksum(string $filename): string
 {
     $contents = file_get_contents($filename);
@@ -239,6 +251,9 @@ foreach ($regions as $region) {
 
     step("Ensure layer is public in {$region}");
     layerEnsureIsPublic($fc, $variant);
+
+    step('Clean up the uploaded package after publishing');
+    fileDelete($oss, $bucketName, $objectName);
 }
 
 step('Publish is done');


### PR DESCRIPTION
This change prevents the retention of runtime packages after releasing layers on Function Compute, which will significantly reduce our storage costs.

## Cost Savings Rationale

Currently, our storage requirements for these packages are substantial:

- **Base Storage**: Each release consumes ~945MB of storage (45MB/artifact * 21 regions).
- **Platform Multiplier**: We maintain support for 4 PHP versions (8.1-8.4) across 2 Debian versions (11 and 12), resulting in an 8x multiplier.
- **Total Storage**: This brings the total storage requirement to 7.56 GB (945MB * 8).

By no longer storing these runtime packages post-release, we can eliminate this storage cost.